### PR TITLE
Fixing an issue with token expiration timestamp on persist/restore.

### DIFF
--- a/Source/YOSSocial/YOSAccessToken.h
+++ b/Source/YOSSocial/YOSAccessToken.h
@@ -40,16 +40,6 @@
 	 * Returns a NSDate representing the application authorization expiry date.
 	 */
 	NSDate			*authExpiresDate;
-	
-	/**
-	 * Returns an integer of the UNIX time that the token will expire.
-	 */
-	NSInteger		tokenExpires;
-	
-	/**
-	 * Returns an integer of the UNIX time that application authorization will expire.
-	 */
-	NSInteger		authExpires;
 }
 
 @property (nonatomic, readwrite, retain) NSString *guid;
@@ -57,8 +47,6 @@
 @property (nonatomic, readwrite, retain) NSString *consumer;
 @property (nonatomic, readwrite, retain) NSDate *tokenExpiresDate;
 @property (nonatomic, readwrite, retain) NSDate *authExpiresDate;
-@property (nonatomic, readwrite) NSInteger tokenExpires;
-@property (nonatomic, readwrite) NSInteger authExpires;
 
 /**
  * Returns an access token for the specified dictionary containing token variables.

--- a/Source/YOSSocial/YOSAccessToken.m
+++ b/Source/YOSSocial/YOSAccessToken.m
@@ -17,8 +17,6 @@
 @synthesize guid;
 @synthesize sessionHandle;
 @synthesize consumer;
-@synthesize tokenExpires;
-@synthesize authExpires;
 @synthesize tokenExpiresDate;
 @synthesize authExpiresDate;
 
@@ -41,8 +39,6 @@
 	[theToken autorelease];
 	[theToken setGuid:[tokenDictionary valueForKey:@"xoauth_yahoo_guid"]];
 	[theToken setSessionHandle:[tokenDictionary valueForKey:@"oauth_session_handle"]];
-	[theToken setTokenExpires:tokenExpires];
-	[theToken setAuthExpires:authExpires];
 	[theToken setTokenExpiresDate:[NSDate dateWithTimeIntervalSinceNow:tokenExpires]];
 	[theToken setAuthExpiresDate:[NSDate dateWithTimeIntervalSinceNow:authExpires]];
 	
@@ -59,10 +55,8 @@
 	[theToken autorelease];
 	[theToken setGuid:[tokenDictionary valueForKey:@"guid"]];
 	[theToken setSessionHandle:[tokenDictionary valueForKey:@"sessionHandle"]];
-	[theToken setTokenExpires:tokenExpires];
-	[theToken setAuthExpires:authExpires];
-	[theToken setTokenExpiresDate:[NSDate dateWithTimeIntervalSinceNow:tokenExpires]];
-	[theToken setAuthExpiresDate:[NSDate dateWithTimeIntervalSinceNow:authExpires]];
+	[theToken setTokenExpiresDate:[NSDate dateWithTimeIntervalSinceReferenceDate:tokenExpires]];
+	[theToken setAuthExpiresDate:[NSDate dateWithTimeIntervalSinceReferenceDate:authExpires]];
 	
 	if([tokenDictionary valueForKey:@"consumer"]) {
 		[theToken setConsumer:[tokenDictionary valueForKey:@"consumer"]];
@@ -76,14 +70,17 @@
 
 - (NSMutableDictionary *)tokenAsDictionary
 {
+	NSInteger tokenExpires = [[self tokenExpiresDate] timeIntervalSinceReferenceDate];
+	NSInteger authExpires = [[self authExpiresDate] timeIntervalSinceReferenceDate];
+  
 	NSMutableDictionary *tokenDictionary = [[NSMutableDictionary alloc] init];
 	[tokenDictionary autorelease];
 	[tokenDictionary setObject:self.key forKey:@"key"];
 	[tokenDictionary setObject:self.secret forKey:@"secret"];
 	[tokenDictionary setObject:self.guid forKey:@"guid"];
 	[tokenDictionary setObject:self.sessionHandle forKey:@"sessionHandle"];
-	[tokenDictionary setObject:[NSNumber numberWithInt:self.tokenExpires] forKey:@"tokenExpires"];
-	[tokenDictionary setObject:[NSNumber numberWithInt:self.authExpires] forKey:@"authExpires"];
+	[tokenDictionary setObject:[NSNumber numberWithDouble:tokenExpires] forKey:@"tokenExpires"];
+	[tokenDictionary setObject:[NSNumber numberWithDouble:authExpires] forKey:@"authExpires"];
 	
 	if(self.consumer) [tokenDictionary setObject:self.consumer forKey:@"consumer"];
 	

--- a/Source/YOSSocial/YOSRequestToken.h
+++ b/Source/YOSSocial/YOSRequestToken.h
@@ -22,11 +22,6 @@
 	NSString		*requestAuthUrl;
 	
 	/**
-	 * Returns an integer of the UNIX time that the token will expire. 
-	 */
-	NSInteger		tokenExpires;
-	
-	/**
 	 * Returns a NSDate representing the expiry date of this token. 
 	 */
 	NSDate			*tokenExpiresDate;
@@ -38,7 +33,6 @@
 }
 
 @property (nonatomic, readwrite, retain) NSString *requestAuthUrl;
-@property (nonatomic, readwrite) NSInteger tokenExpires;
 @property (nonatomic, readwrite, retain) NSDate *tokenExpiresDate;
 @property (nonatomic, readwrite) BOOL callbackConfirmed;
 

--- a/Source/YOSSocial/YOSRequestToken.m
+++ b/Source/YOSSocial/YOSRequestToken.m
@@ -15,7 +15,6 @@
 @implementation YOSRequestToken
 
 @synthesize requestAuthUrl;
-@synthesize tokenExpires;
 @synthesize tokenExpiresDate;
 @synthesize callbackConfirmed;
 
@@ -38,7 +37,6 @@
 	
 	[theToken autorelease];
 	[theToken setRequestAuthUrl:[tokenDictionary valueForKey:@"xoauth_request_auth_url"]];
-	[theToken setTokenExpires:tokenExpires];
 	[theToken setTokenExpiresDate:[NSDate dateWithTimeIntervalSinceNow:tokenExpires]];
 	[theToken setCallbackConfirmed:isCallbackConfirmed];
 	
@@ -53,8 +51,7 @@
 														   andSecret:[tokenDictionary valueForKey:@"secret"]];
 	[theToken autorelease];
 	[theToken setRequestAuthUrl:[tokenDictionary valueForKey:@"requestAuthUrl"]];
-	[theToken setTokenExpires:tokenExpires];
-	[theToken setTokenExpiresDate:[NSDate dateWithTimeIntervalSinceNow:tokenExpires]];
+	[theToken setTokenExpiresDate:[NSDate dateWithTimeIntervalSinceReferenceDate:tokenExpires]];
 	
 	return theToken;
 }
@@ -64,11 +61,13 @@
 
 - (NSMutableDictionary *)tokenAsDictionary
 {
+	NSInteger tokenExpires = [[self tokenExpiresDate] timeIntervalSinceReferenceDate];
+  
 	NSMutableDictionary *tokenDictionary = [[NSMutableDictionary alloc] init];
 	[tokenDictionary autorelease];
 	[tokenDictionary setObject:self.key forKey:@"key"];
 	[tokenDictionary setObject:self.secret forKey:@"secret"];
-	[tokenDictionary setObject:[NSNumber numberWithInt:self.tokenExpires] forKey:@"tokenExpires"];
+	[tokenDictionary setObject:[NSNumber numberWithDouble:tokenExpires] forKey:@"tokenExpires"];
 	[tokenDictionary setObject:self.requestAuthUrl forKey:@"requestAuthUrl"];
 	
 	return tokenDictionary;


### PR DESCRIPTION
I ran into an issue when restoring an access token created during a previous run of my app.  Basically whenever the token was restored it thought it would expire 'one hour from now' instead of 'one hour from my initial creation date' - if the app was shut down for over an hour the token would expire but the app still thought it was good.  This commit fixes this by storing the absolute expiration time.

(For reference, http://code.google.com/p/qsb-mac-plugins/issues/detail?id=5#c12 is the related ticket for the app (actually plugin for an app) in question)
